### PR TITLE
Change RSS feed link to be relative to the site

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
       {% if site.google_plus_link %}<a href="{{ site.google_plus_link }}" target="_new"><i class="fa fa-google-plus"></i></a>{% endif %}
       {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}" target="_new"><i class="fa fa-github-alt"></i></a>{% endif %}
       {% if site.stackoverflow_link %}<a href="{{ site.stackoverflow_link }}" target="_new"><i class="fa fa-stack-overflow"></i></a>{% endif %}
-      <a href="http://www.jacobtomlinson.co.uk/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
+      <a href="{{ site.baseurl }}/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
     </p>
   </div>
 </nav>


### PR DESCRIPTION
I noticed on the mmenu bar that the RSS icon went to `http://www.jacobtomlinson.co.uk/feed.xml` so I fixed it to include the baseurl instead. I guess ideally the link's visibility could be turned on or off from the `_config.yml` but I think you're already working on that in https://github.com/jacobtomlinson/carte-noire/issues/10
