### PR TITLE
Fixes jacobtomlinson/carte-noire#27

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -99,6 +99,8 @@ layout: default
              {% endif %}
             <a href="{{ site.baseurl }}{{ post.url }}">Continue Reading</a>
           </div>
+        {% endfor %}
+        <hr />
           {% if page.previous %}
           <p>
             <a href="{{ site.baseurl }}{{ page.previous.url }}">{{ page.previous.title }}</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -101,6 +101,7 @@ layout: default
           </div>
         {% endfor %}
         <hr />
+        <div class="previous previous-next">
           {% if page.previous %}
           <p>
             <a href="{{ site.baseurl }}{{ page.previous.url }}">{{ page.previous.title }}</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -92,12 +92,13 @@ layout: default
             <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
           </div>
           <div class="excerpt">
-            {{ post.excerpt | strip_html | truncatewords:30 }}
+             {% if post.summary %}
+              {{ post.summary | strip_html | truncatewords:30 }}
+             {% else %}
+              {{ post.excerpt | strip_html | truncatewords:30 }}
+             {% endif %}
             <a href="{{ site.baseurl }}{{ post.url }}">Continue Reading</a>
           </div>
-        {% endfor %}
-        <hr />
-        <div class="previous previous-next">
           {% if page.previous %}
           <p>
             <a href="{{ site.baseurl }}{{ page.previous.url }}">{{ page.previous.title }}</a>


### PR DESCRIPTION
Allow the use of a post's "summary" variable when previewing similar posts rather than the post's excerpt, which can include markdown which will get stripped in creating the excerpt
