### PR TITLE
Fixes jacobtomlinson/carte-noire#27 

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -92,7 +92,11 @@ layout: default
             <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
           </div>
           <div class="excerpt">
-            {{ post.excerpt | strip_html | truncatewords:30 }}
+             {% if post.summary %}
+              {{ post.summary | strip_html | truncatewords:30 }}
+             {% else %}
+              {{ post.excerpt | strip_html | truncatewords:30 }}
+             {% endif %}
             <a href="{{ site.baseurl }}{{ post.url }}">Continue Reading</a>
           </div>
         {% endfor %}


### PR DESCRIPTION
Allow the use of a post's "summary" variable when previewing similar posts rather than the post's excerpt, which can include markdown which will get stripped in creating the excerpt
