### PR TITLE
Added missing `baseurl` to internal links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
       {% if site.google_plus_link %}<a href="{{ site.google_plus_link }}" target="_new"><i class="fa fa-google-plus"></i></a>{% endif %}
       {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}" target="_new"><i class="fa fa-github-alt"></i></a>{% endif %}
       {% if site.stackoverflow_link %}<a href="{{ site.stackoverflow_link }}" target="_new"><i class="fa fa-stack-overflow"></i></a>{% endif %}
-      <a href="http://www.jacobtomlinson.co.uk/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
+      <a href="{{ site.baseurl }}/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
     </p>
   </div>
 </nav>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ layout: default
 
                   {% endfor %}
                   <li>
-                      <small><i><a href="/posts/">more...</a></i></small>
+                      <small><i><a href="{{ site.baseurl }}/posts/">more...</a></i></small>
                   </li>
               </ul>
 

--- a/search.html
+++ b/search.html
@@ -17,7 +17,7 @@ layout: default
   </div>
 </div>
 
-<script src="/js/jekyll-search.js" type="text/javascript"></script>
+<script src="{{ site.baseurl }}/js/jekyll-search.js" type="text/javascript"></script>
 
 <script type="text/javascript">
   SimpleJekyllSearch.init({


### PR DESCRIPTION
All internal links require `baseurl` to be prepended to the path. Some of them are missing, this PR will mop them up.
