### PR TITLE
Moved social links into include

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,19 +1,14 @@
 <nav id="my-menu">
   <div>
     <p>{{ site.title }}</p>
+
     <ul class="pages">
       <li><a href="{{ site.baseurl }}/"><i class="fa fa-home"></i> Home</a></li>
       <li><a href="{{ site.baseurl }}/posts/"><i class="fa fa-archive"></i> All Posts</a></li>
       <li><a href="{{ site.baseurl }}/search/"><i class="fa fa-search"></i> Search</a></li>
     </ul>
-    <p class="links">
-      {% if site.twitter_username %}<a href="http://www.twitter.com/{{ site.twitter_username }}" target="_new"><i class="fa fa-twitter"></i></a>{% endif %}
-      {% if site.linkedin_link %}<a href="{{ site.linkedin_link }}" target="_new"><i class="fa fa-linkedin"></i></a>{% endif %}
-      {% if site.google_plus_link %}<a href="{{ site.google_plus_link }}" target="_new"><i class="fa fa-google-plus"></i></a>{% endif %}
-      {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}" target="_new"><i class="fa fa-github-alt"></i></a>{% endif %}
-      {% if site.stackoverflow_link %}<a href="{{ site.stackoverflow_link }}" target="_new"><i class="fa fa-stack-overflow"></i></a>{% endif %}
-      <a href="{{ site.baseurl }}/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
-    </p>
+
+    {% include social_links.html %}
   </div>
 </nav>
 <div class="menu-button" href="#menu"><i class="fa fa-bars"></i></div>

--- a/_includes/social_links.html
+++ b/_includes/social_links.html
@@ -1,0 +1,8 @@
+<p class="links">
+  {% if site.twitter_username %}<a href="http://www.twitter.com/{{ site.twitter_username }}" target="_new"><i class="fa fa-twitter"></i></a>{% endif %}
+  {% if site.linkedin_link %}<a href="{{ site.linkedin_link }}" target="_new"><i class="fa fa-linkedin"></i></a>{% endif %}
+  {% if site.google_plus_link %}<a href="{{ site.google_plus_link }}" target="_new"><i class="fa fa-google-plus"></i></a>{% endif %}
+  {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}" target="_new"><i class="fa fa-github-alt"></i></a>{% endif %}
+  {% if site.stackoverflow_link %}<a href="{{ site.stackoverflow_link }}" target="_new"><i class="fa fa-stack-overflow"></i></a>{% endif %}
+  <a href="{{ site.baseurl }}/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
+</p>

--- a/css/style.scss
+++ b/css/style.scss
@@ -272,6 +272,10 @@ ul {
 		}
 	}
 
+	.links {
+		font-size: 2em;
+	}
+
 	.articles {
 		text-align: center;
 		font-size: 20px;

--- a/index.html
+++ b/index.html
@@ -18,14 +18,7 @@ layout: default
                 {{ site.title_description }}
             </div>
 
-            <div class="links">
-                {% if site.twitter_username %}<a href="http://www.twitter.com/{{ site.twitter_username }}" target="_new"><i class="fa fa-twitter fa-2x"></i></a>{% endif %}
-                {% if site.linkedin_link %}<a href="{{ site.linkedin_link }}" target="_new"><i class="fa fa-linkedin fa-2x"></i></a>{% endif %}
-                {% if site.google_plus_link %}<a href="{{ site.google_plus_link }}" target="_new"><i class="fa fa-google-plus fa-2x"></i></a>{% endif %}
-                {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}" target="_new"><i class="fa fa-github-alt fa-2x"></i></a>{% endif %}
-                {% if site.stackoverflow_link %}<a href="{{ site.stackoverflow_link }}" target="_new"><i class="fa fa-stack-overflow fa-2x"></i></a>{% endif %}
-                <a href="feed.xml" target="_new"><i class="fa fa-rss fa-2x"></i></a>
-            </div>
+            {% include social_links.html %}
           </div>
           <div class="col-md-12 main content-panel">
 


### PR DESCRIPTION
Previously the social links were both in the `index.html` and the `header.html` files with slightly different classes.

I've moved them into one include to make changing them easier and updated the styling to be different based on the include location.

Fixes #21.
