### PR TITLE
Some small fixes

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,7 +42,7 @@ layout: default
             {% endif %}
           </span>
           on <span itemprop="datePublished" content="2014-08-28">{{ page.date | date: "%B %-d, %Y" }}</span>
-          under {% if page.categories %}{% for category in page.categories limit:1 %}{{ category }}{% endfor %}{% endif %}
+          {% if page.categories != empty %} under {% for category in page.categories limit:1 %}{{ category }}{% endfor %}{% endif %}
         </i></small>
       </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,20 +27,20 @@ layout: default
 
       <div class="author">
         <small><i>
+          {% if page.author %}
           by
           <span itemprop="author">
             {% if site.google_plus_link %}
               <a rel="author" href="{{ site.google_plus_link }}">
             {% endif %}
-            {% if page.author %}
             <span itemprop="author" itemscope itemtype="http://schema.org/Person">
               <span itemprop="name">{{ page.author }}</span>
             </span>
-            {% endif %}
             {% if site.google_plus_link %}
               </a>
             {% endif %}
           </span>
+          {% endif %}
           on <span itemprop="datePublished" content="2014-08-28">{{ page.date | date: "%B %-d, %Y" }}</span>
           {% if page.categories != empty %} under {% for category in page.categories limit:1 %}{{ category }}{% endfor %}{% endif %}
         </i></small>


### PR DESCRIPTION
Hi

I moved some `if` definitions, so if there are no defined attributes, like `categories` or `author`, you won't see texts in the post page like `by` or `under` without the following text.
Another thing, if `page.categories` is not defined, anyway comes with an empty array `[]`, so `{% if page.categories %}` is always true, because of that I changed it.
