### PR TITLE
Don't show related post panel if no related posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -87,6 +87,7 @@ layout: default
       </div>
       {% endif %}
 
+      {% if site.related_posts.length > 0 %}
       <div class="content-panel related clearfix">
         {% for post in site.related_posts limit:1 %}
         <div class="related-header">
@@ -122,6 +123,7 @@ layout: default
           {% endif %}
         </div>
       </div>
+      {% endif %}
 
     </div>
 


### PR DESCRIPTION
Thanks for the fantastic theme. 

I noticed one bug that I addressed in this PR: If there are no related posts, the panel still appears but shows no content.

| Before fix | After fix |
| --- | --- |
| <img width="1122" alt="screen shot 2015-11-19 at 2 00 22 pm" src="https://cloud.githubusercontent.com/assets/4391203/11284713/f3f060ba-8ed0-11e5-94c7-bb57c4496af3.png"> | <img width="1043" alt="screen shot 2015-11-19 at 3 20 26 pm" src="https://cloud.githubusercontent.com/assets/4391203/11284747/21ed7d22-8ed1-11e5-9805-e9bcc7d96115.png"> |
